### PR TITLE
feat(identity): bootstrap logger and standardize error format

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,6 +22,7 @@ files {
 
 server_scripts {
   'server/config.lua',
+  'server/logger.lua',
   'server/identity_svc.lua',
   'server/main.lua'
 }

--- a/server/config.lua
+++ b/server/config.lua
@@ -6,4 +6,5 @@ AxIdentity.cfg = {
   mask_license        = true,
   mask_prefix         = 8,
   auto_open_on_ready  = true,   -- << NEU: beim Charakter-Ready automatisch öffnen
+  log_level           = 'info',
 }

--- a/server/identity_svc.lua
+++ b/server/identity_svc.lua
@@ -208,7 +208,7 @@ end
 function AxIdentity.svc.getSafe(target)
   local data = AxIdentity.svc.resolveTarget(target)
   if not data then
-    return { ok=false, code='E_NOT_FOUND', msg='identity not found' }
+    return { ok=false, error={ code='E_NOT_FOUND', message='identity not found' } }
   end
   return { ok=true, data=data }
 end

--- a/server/logger.lua
+++ b/server/logger.lua
@@ -1,0 +1,37 @@
+AxIdentity = AxIdentity or {}
+
+local cfg = AxIdentity.cfg or {}
+
+local LEVELS = { error = 0, warn = 1, info = 2, debug = 3 }
+local current = LEVELS[cfg.log_level or 'info'] or LEVELS.info
+
+local function should(level)
+  return LEVELS[level] <= current
+end
+
+local function format(level, cid, msg, ...)
+  local prefix = ('[ax_identity][%s]'):format(level)
+  if cid then prefix = prefix .. ('[' .. cid .. ']') end
+  local body = msg and msg:format(...) or ''
+  return prefix .. ' ' .. body
+end
+
+AxIdentity.log = {}
+
+function AxIdentity.log.newCid()
+  return ('%08x'):format(math.random(0, 0xffffffff))
+end
+
+function AxIdentity.log.info(cid, msg, ...)
+  if should('info') then print(format('info', cid, msg, ...)) end
+end
+
+function AxIdentity.log.warn(cid, msg, ...)
+  if should('warn') then print(format('warn', cid, msg, ...)) end
+end
+
+function AxIdentity.log.error(cid, msg, ...)
+  if should('error') then print(format('error', cid, msg, ...)) end
+end
+
+return AxIdentity.log

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,4 +1,4 @@
-local log = (Axiom and Axiom.log) or { info=print, warn=print, error=print }
+local log = AxIdentity.log
 local cfg = AxIdentity and AxIdentity.cfg or {}
 local SVC = AxIdentity.svc
 
@@ -18,6 +18,7 @@ end
 -- Auto-Open UI, wenn der Core meldet "character ready"
 -- Core kann (cid, uid [, src]) senden – src ist optional
 RegisterNetEvent('Axiom:character:ready', function(cid, uid, evSrc)
+  local reqId = log.newCid()
   if not cfg.auto_open_on_ready then return end
   if not uid or not cid then return end
 
@@ -41,5 +42,5 @@ RegisterNetEvent('Axiom:character:ready', function(cid, uid, evSrc)
   -- ViewModel + an Client schicken → Client öffnet UI
   local vm = SVC.viewModel(data)
   TriggerClientEvent('axi-id:response', targetSrc, { ok=true, data=vm })
-  log.info('[ax_identity] auto-open sent to src=%s uid=%s cid=%s', tostring(targetSrc), tostring(vm.uid), tostring(cid))
+  log.info(reqId, 'auto-open sent to src=%s uid=%s cid=%s', tostring(targetSrc), tostring(vm.uid), tostring(cid))
 end)


### PR DESCRIPTION
## Problem
- Server logs lack correlation identifiers and cannot be filtered by log level.
- Error responses return inconsistent shapes.

## Solution
- Add configurable logger with correlation IDs and level filtering.
- Include logger in `fxmanifest.lua` so it loads before service modules.
- Extend server config with `log_level` option.
- Standardize `getSafe` error output to `{ ok=false, error={ code, message } }`.

## Tests / Manual Steps
- `luac -p fxmanifest.lua` *(command not found)*
- `apt-get update` *(403 Forbidden; unable to install Lua for syntax checks)*

## Risks
- Logger relies on Lua environment; runtime issues might surface without further testing.

## Rollback
- Revert commit `feat(identity): add request logger and unified error format`.

------
https://chatgpt.com/codex/tasks/task_e_689e3d113bd4832fa3c93701bc3b170d